### PR TITLE
Add action to return array of unassigned devices

### DIFF
--- a/source/UnassignedDevices.php
+++ b/source/UnassignedDevices.php
@@ -465,6 +465,14 @@ switch ($_POST['action']) {
 	case 'remove_hook':
 		@unlink($paths['reload']);
 		break;
+		
+	case 'get_content_json':
+		unassigned_log("Starting json reply action [get_content_json]", "DEBUG");
+		$time		 = -microtime(true); 
+		$disks = get_all_disks_info();
+		echo json_encode($disks);
+		unassigned_log("Total render time: ".($time + microtime(true))."s", "DEBUG");
+		break;
 
 	/*	CONFIG	*/
 	case 'automount':


### PR DESCRIPTION
This adds an action that returns a json encoded list of unassigned devices, so it's easier to parse by third-party components.