### PR TITLE
Skip mountpoint creation if it already exists.

### DIFF
--- a/unassigned.devices.plg
+++ b/unassigned.devices.plg
@@ -1019,18 +1019,20 @@ chown nobody:users /mnt/disks
 chmod 777 /var/state/&name;
 
 # create a tmpfs mountpoint at /mnt/disks
-# to make sure that a CIFS connection dropout doesn't fill all RAMFS
+# to make sure that a CIFS connection dropout doesn't fill all rootfs
 # ps: tmpfs mountpoint will only be created if no disks are mounted yet
 mounted_disks="n"
-for dir in /mnt/disks/*; do 
-  if mountpoint -q "$dir" 2>/dev/null; then 
-    mounted_disks="y" 
+if ! mountpoint -q /mnt/disks 2>/dev/null; then
+  for dir in /mnt/disks/*; do 
+    if mountpoint -q "$dir" 2>/dev/null; then 
+      mounted_disks="y" 
+    fi
+  done
+  if [ $mounted_disks == "n" ]; then
+    mount -t tmpfs -o size=1M tmpfs /mnt/disks
+  else
+    touch /var/state/&name;/reboot_required
   fi
-done
-if [ $mounted_disks == "n" ]; then
-  mount -t tmpfs -o size=1M tmpfs /mnt/disks
-else
-  touch /var/state/&name;/reboot_required
 fi
 
 # Add unassigned_devices to smb-extra.conf.


### PR DESCRIPTION
This prevents a small bug in requesting a server reboot if the /mnt/disks directory is already a mountpoint. Since it won't break anything until the next update, it can be committed now and released later, if it's the case.