### PR TITLE
Fix typo in SMB Extras Configuration

### DIFF
--- a/unassigned.devices.plg
+++ b/unassigned.devices.plg
@@ -970,7 +970,7 @@ rm -f /tmp/start_unassigned_devices 2>/dev/null
 <INLINE>
 <![CDATA[
 #unassigned_devices_start
-#Unassigned devices share includes
+#unassigned devices share includes
    include = /tmp/unassigned.devices/smb-settings.conf
 #unassigned_devices_end
 ]]>


### PR DESCRIPTION
Make header of each section in SMB Extras all following the same casing (lower case) for consistency.

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>