### PR TITLE
ping undefined behavior / multiple gateways

### DIFF
--- a/source/event/started
+++ b/source/event/started
@@ -9,7 +9,7 @@ logger "Mounting 'Auto Mount' Remote Shares..." -t"unassigned.devices"
 # Wait until network is ready
 timer=30
 while [ $timer -gt 0 ]; do
-	gateway=$(route -n | awk '/^0.0.0.0/ {print $2}')
+	gateway=$(route -n | awk '/^0.0.0.0/ {print $2; exit}')
 	if [ -n "$gateway" ] && [ $(ping -q -n -c 1 $gateway | awk -F, '/received/ {print $2}' | awk '{print $1}') -eq 1 ]; then
 		break
 	fi


### PR DESCRIPTION
If running Unraid with multiple gateways (nics/vlans), this line will grab multiple IP addresses. `gateway` becomes a string of multiple IPs passed to ping. This results in undefined behavior, a timeout and slows down nginx initialization for ~5 minutes after boot.

This change exits after the first routable IP is matched.