### PR TITLE
Better handling of form events

### DIFF
--- a/source/EditSettings.page
+++ b/source/EditSettings.page
@@ -356,22 +356,26 @@ _(Volume)_
 
 	<?if (isset($_GET['s'])):?>
 		$( "form" ).submit(function( event ) {
-			$.post(UDURL,{action:"set_command",serial:"<?=$ud_device;?>",part:"<?=$partition;?>",command:$("input[name='#file']").val(),user_command:$("input[name='#user_file']").val()},function(data){event.preventDefault()},"json");
+			event.preventDefault();
+			$.post(UDURL,{action:"set_command",serial:"<?=$ud_device;?>",part:"<?=$partition;?>",command:$("input[name='#file']").val(),user_command:$("input[name='#user_file']").val()},function(data){event.target.submit()},"json");
 		});
 		<?if ($fstype == "apfs"):?>
 			$( "form" ).submit(function( event ) {
-				$.post(UDURL,{action:"set_volume",serial:"<?=$ud_device;?>",part:"<?=$partition;?>",volume:$("input[name='#volume']").val()},function(data){event.preventDefault()},"json");
+				event.preventDefault();
+				$.post(UDURL,{action:"set_volume",serial:"<?=$ud_device;?>",part:"<?=$partition;?>",volume:$("input[name='#volume']").val()},function(data){event.target.submit()},"json");
 			});
 		<?endif;?>
 	<?endif;?>
 	<?if (isset($_GET['d'])):?>
 		$( "form" ).submit(function( event ) {
-			$.post(UDURL,{action:"set_samba_command",device:"<?=$device;?>",command:$("input[name='#file']").val(),user_command:$("input[name='#user_file']").val()},function(data){event.preventDefault()},"json");
+			event.preventDefault();
+			$.post(UDURL,{action:"set_samba_command",device:"<?=$device;?>",command:$("input[name='#file']").val(),user_command:$("input[name='#user_file']").val()},function(data){event.target.submit()},"json");
 		});
 	<?endif;?>
 	<?if (isset($_GET['i'])):?>
 		$( "form" ).submit(function( event ) {
-			$.post(UDURL,{action:"set_iso_command",device:"<?=$device;?>",command:$("input[name='#file']").val()},function(data){event.preventDefault()},"json");
+			event.preventDefault();
+			$.post(UDURL,{action:"set_iso_command",device:"<?=$device;?>",command:$("input[name='#file']").val()},function(data){event.target.submit()},"json");
 		});
 	<?endif;?>
 


### PR DESCRIPTION
When submitting the EditSettings.php main <form> element:
 - call preventDefault() right away, then manually submit the form after we've $.post-ed the changes we want
 - this prevents us from discarding the XHR request if the form submit request goes through before the XHR goes through (causes the page to reload and not see the new updates yet)